### PR TITLE
🙀 CAT-21: Experimental Non-Standard Low Fee Transactions

### DIFF
--- a/frontend/src/app/components/ordinals/cat21-mint/cat21-mint.component.html
+++ b/frontend/src/app/components/ordinals/cat21-mint/cat21-mint.component.html
@@ -106,7 +106,8 @@
                 We automatically select your largest UTXO, but feel free to select a different one if you like:
               </p>
 
-              <a *ngIf="minRequiredFee != 1" href="javascript:void(0)" (click)="updateMinRequiredFee(1)">⚠️ Click here to disable the required fee rate check (do you know what you are doing!?)</a>
+              <a *ngIf="minRequiredFee != 0" href="javascript:void(0)" (click)="updateMinRequiredFee(0)">⚠️ Click here to disable the required fee rate check.</a>
+              <span *ngIf="minRequiredFee == 0">⚠️ Required fee rate check disabled. You can enter any value!</span>
 
               <div class="mt-4 pl-2 pr-2 pt-1 pb-1 shape-border" *ngFor="let x of paymentOutputs$ | async"
                 [ngClass]="{ selected: x === this.selectedPaymentOutput }">

--- a/frontend/src/app/components/ordinals/cat21-mint/cat21-mint.component.ts
+++ b/frontend/src/app/components/ordinals/cat21-mint/cat21-mint.component.ts
@@ -146,7 +146,9 @@ export class Cat21MintComponent implements OnInit {
               BigInt(0)
             );
 
-            const transactionFee = BigInt(simulation1.vsize * feeRate);
+            // Since feeRate no longer has to be an integer, we can also have floating point numbers here
+            const transactionFeeFloating = simulation1.vsize * feeRate;
+            const transactionFee = BigInt(Math.ceil(transactionFeeFloating));
 
             // simulate the transaction again, with exact transactionFee
             const simulation2 = this.cat21Service.simulateTransaction(
@@ -224,7 +226,7 @@ export class Cat21MintComponent implements OnInit {
     this.cfeeRate.setValidators([
       Validators.required,
       Validators.min(this.minRequiredFee),
-      fullNumberValidator()
+      // fullNumberValidator()
     ]);
 
     if (this.cfeeRate.value < this.minRequiredFee) {


### PR DESCRIPTION
- Added support for transactions with a fee rate below 1 sat/vB, which is within **consensus** but violates the **minRelayTxFee** of 1 sat/B.  
- These transactions are valid but will not be relayed by default nodes.  
- The code is maintained in a separate branch for potential future use (e.g., exporting transactions to **Mara Slipstream**).  

<img width="1024" alt="Screenshot 2025-02-03 at 16 22 07" src="https://github.com/user-attachments/assets/2145cf71-6f65-4e7b-9214-5b9e8fc0dcef" />
